### PR TITLE
Remove 90vw on table header at 1440px

### DIFF
--- a/style.css
+++ b/style.css
@@ -486,7 +486,6 @@ h1 {
 	font-weight: 700;
 	border-radius: 3px 3px 0 0;
 	padding: 0 0 0 2rem;
-	width: 90vw;
 }
 
 .table-data {


### PR DESCRIPTION
Remember this for the future.  
This sole 90vw width on the .table-header made the ENTIRE site look far too zoomed in.